### PR TITLE
Fix query builder to support EXISTS conditions

### DIFF
--- a/app/utils/queryBuilder.js
+++ b/app/utils/queryBuilder.js
@@ -24,9 +24,10 @@ function buildWhereClause(conditions, startIndex = 1) {
 
   validConditions.forEach(condition => {
     const { field, operator = '=', value, type = 'exact' } = condition;
-    
+
     // Validate field name to prevent injection
-    if (!isValidFieldName(field)) {
+    // "EXISTS" is a special case used for subqueries
+    if (type !== 'exists' && !isValidFieldName(field)) {
       throw new Error(`Invalid field name: ${field}`);
     }
 


### PR DESCRIPTION
## Summary
- update field validation in query builder to skip validation on EXISTS conditions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe9b97e0832ba37df371dfd03aad